### PR TITLE
added 1&1

### DIFF
--- a/_providers/1und1.de.md
+++ b/_providers/1und1.de.md
@@ -1,0 +1,17 @@
+---
+name: 1&1
+status: OK
+domains:
+  - custom
+server:
+  - type: imap
+    socket: STARTTLS
+    hostname: imap.ionos.com
+    port: 143
+  - type: smtp
+    socket: STARTTLS
+    hostname: smtp.ionos.com
+    port: 587
+website: https://ionos.com
+---
+


### PR DESCRIPTION
closes #23 

I left out `last_checked`, as we have this info solely from https://www.ionos.com/help/email/other-email-programs/add-a-mail-basic-email-account-to-mozilla-thunderbird/