### PR TITLE
re-added autistici.org

### DIFF
--- a/_providers/autistici.org.md
+++ b/_providers/autistici.org.md
@@ -1,0 +1,17 @@
+---
+name: Autistici/Inventati
+status: OK
+domains: 
+  - autistici.org
+server:
+  - type: imap
+    socket: SSL
+    hostname: mail.autistici.org
+    port: 993
+  - type: smtp
+    socket: SSL
+    hostname: smtp.autistici.org
+    port: 465
+last_checked: 2018-01
+website: https://www.autistici.org/
+---

--- a/_providers/old/autistici.org.md
+++ b/_providers/old/autistici.org.md
@@ -1,9 +1,0 @@
----
-name: Autistici/Inventati
-website: https://www.autistici.org/
-domains: autistici.org
-credentials: emailPass
-status:
- state: OK
- date: 2018-01
----


### PR DESCRIPTION
Needs to be re-added. It seemed to always work OK. I found the server parameters at https://www.autistici.org/docs/mail/connectionparms