### PR TITLE
added mailo.com

### DIFF
--- a/_providers/mailo.com
+++ b/_providers/mailo.com
@@ -1,0 +1,17 @@
+---
+name: mailo.com
+status: OK
+domains:
+  - mailo.com
+servers:
+  - type: imap
+    socket: SSL
+    hostname: imap.mailo.com
+    port: 993
+  - type: smtp
+    socket: SSL
+    hostname: smtp.mailo.com
+    port: 465
+last_checked: 2020-02
+website: mailo.com
+---


### PR DESCRIPTION
closes #89 

tested it out. I had to guess the servers, but even entering them manually works. They seem to show to the same server for now. Should be backwards-compatible even if they expand their infrastructure.