### PR TITLE
clarify what happens when no servers are defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ domains:
   - used_by_this_provider
 server:
   # Repeat the following block for each server (usually one for imap, one for smtp).
+  # If no servers are defined, autoconfig, autodiscover or guessing is used;
+  # this will lead to the same server-configuration as if there is no provider-entry at all.
   - type: [IMAP or SMTP]
     socket: [SSL or STARTTLS]
     hostname: [hostname to connect to]


### PR DESCRIPTION
it was a bit unclear to me (or i forgot it),
what happens when no servers are defined.

i suspected, that in this case, autoconfig/autodiscover are skipped -
which may have led to a worsening when for a provider a provider-entry is defined.

however, in fact, this is not the case.

the rust-core does not differ between missing provider-entries
or provider-entries without servers -
get_offline_autoconfig() just returns None in both cases.

for accessing additional information from a provider-entry,
there is an additional function, get_provider_info()

targets #113 