### PR TITLE
some nauta.cu config-defaults

### DIFF
--- a/_providers/nauta.cu.md
+++ b/_providers/nauta.cu.md
@@ -15,6 +15,13 @@ server:
 after_login_hint: |
     Atención - con nauta.cu, puede enviar mensajes sólo a un máximo de 20 personas a la vez.
     En grupos más grandes, no puede enviar mensajes o abandonar el grupo.
+config_defaults:
+  bcc_self: 0
+  sentbox_watch: 0
+  mvbox_watch: 0
+  mvbox_move: 0
+  e2ee_enabled: 0
+  media_quality: 1
 last_checked: 2020-01
 website: https://webmail.nauta.cu
 ---

--- a/_providers/nauta.cu.md
+++ b/_providers/nauta.cu.md
@@ -16,6 +16,7 @@ after_login_hint: |
     Atención - con nauta.cu, puede enviar mensajes sólo a un máximo de 20 personas a la vez.
     En grupos más grandes, no puede enviar mensajes o abandonar el grupo.
 config_defaults:
+  delete_server_after: 1
   bcc_self: 0
   sentbox_watch: 0
   mvbox_watch: 0


### PR DESCRIPTION
cc @adbenitez 

later, in another pr, we can also enable `delete_server_after`, maybe it is a good idea, not sure. but in any case, i would give server-autodeletion a bit more time to be opt-in tested.