### PR TITLE
Mark oauth2 providers as such

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,26 @@ The provider-specific-defaults are applied _once_
 after the first successful configuration,
 they are not applied later on re-configures or on updates -
 reason for that is to respect user-choice of changing these values.
+
+
+## OAuth2
+
+With the top-level option `oauth2=AUTHORIZER` you can specify,
+that emails on the given domains support OAuth2 with the given authorizers.
+Supported authorizers are `yandex` and `gmail`.
+
+In contrast to other authorization methods, you cannot use oauth2
+only because the server may support it.
+New Oauth2 authorizers require adaptions in deltachat-core
+and typically also bureaucratic effort.
+
+### Use OAuth2 together with other options
+
+If for an entered address, OAuth2 is supported,
+and the used client supports OAuth2,
+the user will be asked if he wants to continue with that.
+
+Only if that is _cancelled_, the `before_login_hint` is shown;
+so it is not needed to say sth. about OAuth2 before login.
+
+All other options are applied as usual.

--- a/_providers/gmail.md
+++ b/_providers/gmail.md
@@ -4,6 +4,7 @@ status: PREPARATION
 domains:
   - gmail.com
   - googlemail.com
+oauth2: gmail
 strict_tls: true
 server:
   - type: imap

--- a/_providers/yandex.ru.md
+++ b/_providers/yandex.ru.md
@@ -2,8 +2,14 @@
 name: yandex.ru
 status: PREPARATION
 domains:
-- yandex.ru
 - yandex.com
+- yandex.by
+- yandex.kz
+- yandex.ru
+- yandex.ua
+- ya.ru
+- narod.ru
+oauth2: yandex
 strict_tls: true
 before_login_hint: |
   For Yandex accounts, you have to set IMAP protocol option turned on.


### PR DESCRIPTION
the idea of this pr is to use the provider-db as a whitelist and a blacklist for domains supporting some oauth2-providers:

- if the line `oauth2 = yandex | gmail` is present for a provider/domain, we know, that oauth2 is supported
- if no `oauth2` line is present, we know that oauth2 is not supported and **we can skip the mx-lookup**, which may also consume some time, see https://github.com/deltachat/deltachat-android/issues/1426 and is not needed in most cases.

apart from that, the code at https://github.com/deltachat/deltachat-core-rust/blob/master/src/oauth2.rs#L273 can be streamlined and it is no longer needed to maintain a whiltelist of domains there - and to keep it in sync with the provider-db.

morever, this pr syncs the list of domains between oauth2.rs and provider.db - maybe a last time :)

merging this pr in does not require immediately adaption to the rust-core, it only adds a flag that is ignored for now.