### PR TITLE
WIP: sdf.org

### DIFF
--- a/_providers/sdf.org.md
+++ b/_providers/sdf.org.md
@@ -1,0 +1,24 @@
+---
+name: sdf.org
+status: PREPARATION
+domains:
+  - sdf.org
+server:
+  - type: imap
+    socket: SSL
+    hostname: mx.sdf.org
+    port: 993
+    username: EMAILLOCALPART
+  - type: smtp
+    socket: STARTTLS
+    hostname: smtp.example.com
+    port: 587
+    username: EMAILADDRESS
+before_login_hint: You need to create an SMTP AUTH secret at the shell.
+last_checked: 2020-06
+website: https://sdf.org
+---
+
+For more information about how to configure SMTP authentication, see the
+[sdf.org docs](https://sdf.org/?tutorials/smtpauth).
+


### PR DESCRIPTION
Sources:

* Seems to work after manual configuration: https://support.delta.chat/t/login-preferably-by-ssh-to-sdf-org/1049/10
* This is their official documentation: https://sdf.org/?tutorials/smtpauth

I'm not sure how we can integrate this (and whether it's worth the effort). The SMTP auth username is very non-standard, and maybe has to be specified manually anyway.

Apart from the SMTP auth username, this config should work.