### PR TITLE
Remove outdated five.chat server list.

### DIFF
--- a/_providers/five.chat.md
+++ b/_providers/five.chat.md
@@ -4,19 +4,6 @@ status: OK
 domains:
 - five.chat
 strict_tls: true
-server:
-- type: imap
-  hostname: five.chat
-  port: 143
-  socket: STARTTLS
-- type: imap
-  hostname: five.chat
-  port: 993
-  socket: SSL
-- type: smtp
-  hostname: five.chat
-  port: 587
-  socket: STARTTLS
 config_defaults:
   bcc_self: 1
   sentbox_watch: 0


### PR DESCRIPTION
New list can be retrieved by HTTPS, and all these ports can be guessed
if HTTPS fails.