### PR TITLE
update buzon.uy

### DIFF
--- a/_providers/buzon.uy.md
+++ b/_providers/buzon.uy.md
@@ -6,13 +6,13 @@ domains:
 strict_tls: true
 server:
 - type: imap
-  hostname: buzon.uy
+  hostname: mail.buzon.uy
   port: 143
   socket: STARTTLS
 - type: smtp
-  hostname: buzon.uy
+  hostname: mail.buzon.uy
   port: 587
   socket: STARTTLS
-last_checked: 2020-08
+last_checked: 2020-10
 website: https://buzon.uy
 ---


### PR DESCRIPTION
buzon.uy did some changes in DNS (they said that the reason was to avoid getting in blacklisted by some servers) so now IMAP and SMTP servers are `mail.buzon.uy`