### PR TITLE
adapt to rename of 'fetch_existing'

### DIFF
--- a/_providers/nauta.cu.md
+++ b/_providers/nauta.cu.md
@@ -23,7 +23,7 @@ config_defaults:
   mvbox_move: 0
   e2ee_enabled: 0
   media_quality: 1
-  fetch_existing: 0
+  fetch_existing_msgs: 0
 last_checked: 2020-10
 website: https://webmail.nauta.cu
 ---


### PR DESCRIPTION
'fetch_existing' will be renamed to 'fetch_existing_msgs', see https://github.com/deltachat/deltachat-core-rust/pull/2042 - current default is `0`, however, that may change and for nauta we will probably keep skeptical on this option.