### PR TITLE
Add google.com to the list of Gmail domains

### DIFF
--- a/_providers/gmail.md
+++ b/_providers/gmail.md
@@ -4,6 +4,7 @@ status: PREPARATION
 domains:
   - gmail.com
   - googlemail.com
+  - google.com
 oauth2: gmail
 strict_tls: true
 server:


### PR DESCRIPTION
I have no Google account to try, but GSuite (Google Workspace) uses
ASPMX.L.GOOGLE.COM. in MX records so this will be needed if provider is
identified via MX lookup.

This is what Thunderbird does, too:
https://autoconfig.thunderbird.net/v1.1/google.com