### PR TITLE
disable strict_tls explicitly for nauta

### DIFF
--- a/_providers/nauta.cu.md
+++ b/_providers/nauta.cu.md
@@ -4,6 +4,7 @@ domains:
   - nauta.cu
 status: OK
 max_smtp_rcpt_to: 20
+strict_tls: false
 server:
   - type: imap
     socket: STARTTLS


### PR DESCRIPTION
with https://github.com/deltachat/deltachat-core-rust/pull/2121, all providers from the provider-db will use get strict_tls=true as a default setting, this pr changes keeps strict_tls=false explicitly for nauta.

all other providers in the provider-db should be able to handle strict_tls=true as this is the new default.