### PR TITLE
fastmail: add "server" section

### DIFF
--- a/_providers/fastmail.md
+++ b/_providers/fastmail.md
@@ -2,7 +2,21 @@
 name: Fastmail
 status: PREPARATION
 domains: 
-- fastmail.com
+  - fastmail.com
+# Servers list from https://www.fastmail.help/hc/en-us/articles/1500000278342
+server:
+  - type: imap
+    socket: SSL
+    hostname: imap.fastmail.com
+    port: 993
+  - type: smtp
+    socket: SSL
+    hostname: smtp.fastmail.com
+    port: 465
+  - type: smtp
+    socket: STARTTLS
+    hostname: smtp.fastmail.com
+    port: 587
 before_login_hint: "You must create an app-specific password for Delta Chat before you can log in."
 last_checked: 2020-01
 website: https://fastmail.com


### PR DESCRIPTION
fastmail.com has ports 143, 465, 587 and 993 filtered,
causing a timeout on the client before the correct server is tried.

Specifying the server list speeds up configuration in this case.