### PR TITLE
Warn about Fastmail custom domain configuration

### DIFF
--- a/_providers/fastmail.md
+++ b/_providers/fastmail.md
@@ -34,6 +34,6 @@ Then, click "Next" again and then "Done".
 
 Afterwards you can use Delta Chat as usual.
 
-### Custom domains
+## Custom domains
 
 If your login email does not end with `@fastmail.com`, you will need to manually type server information by clicking "Advanced" in Delta Chat and entering the details specified in the "Technical specs" link below.

--- a/_providers/fastmail.md
+++ b/_providers/fastmail.md
@@ -33,3 +33,7 @@ at "Settings / Import & Setup / Setup Guides / Thunderbird / Next":
 Then, click "Next" again and then "Done".
 
 Afterwards you can use Delta Chat as usual.
+
+### Custom domains
+
+If your login email does not end with `@fastmail.com`, you will need to manually type server information by clicking "Advanced" in Delta Chat and entering the details specified in the "Technical specs" link below.


### PR DESCRIPTION
Took me a while to figure this out, but if you log in with an email based on a custom domain, Delta Chat will time out as it will not find the correct servers and ports.