### PR TITLE
Add domain posteo.it for use in email address

### DIFF
--- a/_providers/posteo.md
+++ b/_providers/posteo.md
@@ -26,6 +26,7 @@ domains:
   - posteo.ie
   - posteo.in
   - posteo.is
+  - posteo.it
   - posteo.jp
   - posteo.la
   - posteo.li

--- a/_providers/posteo.md
+++ b/_providers/posteo.md
@@ -62,6 +62,6 @@ server:
   port: 587
   socket: STARTTLS
   type: smtp
-last_checked: 2017-06
+last_checked: 2021-07
 website: https://posteo.de/
 ---


### PR DESCRIPTION
Somehow the domain `posteo.it` has not been included, but it does exist, according to [this Posteo support article](https://posteo.de/en/help/which-domains-are-available-to-use-as-a-posteo-alias-address).