### PR TITLE
app password generation process has changed for fastmail

### DIFF
--- a/_providers/fastmail.md
+++ b/_providers/fastmail.md
@@ -26,11 +26,15 @@ To use Delta Chat with your Fastmail email address
 you have to generate a specific password for it.
 
 You can do that in the Fastmail web interface
-at "Settings / Account: Password & Security / App Passwords: Manage":
+at "Settings / Account: Password & Security / Third-Party-Apps: Add":
 
-1. Click "New App Password".
-2. Click "Generate password". You can optionally select a custom "Name" for this password to make it easier to find later.
-3. Enter the 16-digit password shown there into the Delta Chat password field.
+1. Enter your Password to be able to make changes. Then click "New App Password".
+2. Choose a new name for the password.
+3. At access, choose "Mail (IMAP/POP/SMTP)"
+4. Click "Generate password".
+5. Enter the 16-digit password shown there into the Delta Chat password field.
+   **Careful** - leave out the spaces, it's just 16 digits. Better copy-paste
+   it.
 
 Afterwards you can use Delta Chat as usual.
 

--- a/_providers/fastmail.md
+++ b/_providers/fastmail.md
@@ -30,7 +30,7 @@ at "Settings / Account: Password & Security / Third-Party-Apps: Add":
 
 1. Enter your Password to be able to make changes. Then click "New App Password".
 2. Choose a new name for the password.
-3. At access, choose "Mail (IMAP/POP/SMTP)"
+3. At access, choose "Mail (IMAP/POP/SMTP)".
 4. Click "Generate password".
 5. Enter the 16-digit password shown there into the Delta Chat password field.
    **Careful** - leave out the spaces, it's just 16 digits. Better copy-paste


### PR DESCRIPTION
While creating test accounts, I found out that the steps have been slightly reworded. So I changed the description: