### PR TITLE
document `socket: PLAIN`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ server:
   # If no servers are defined, autoconfig, autodiscover or guessing is used;
   # this will lead to the same server-configuration as if there is no provider-entry at all.
   - type: [IMAP or SMTP]
-    socket: [SSL or STARTTLS]
+    socket: [SSL or STARTTLS or PLAIN]
     hostname: [hostname to connect to]
     port: [port number]
     username_pattern: [optional: EMAIL or EMAILLOCALPART, default is EMAIL]


### PR DESCRIPTION
it is supported by deltachat-core-rust as of
https://github.com/deltachat/deltachat-core-rust/pull/2604
and used eg. by
https://github.com/deltachat/provider-db/pull/195