### PR TITLE
disable yggmail strict_tls

### DIFF
--- a/_providers/yggmail.md
+++ b/_providers/yggmail.md
@@ -3,6 +3,7 @@ name: Yggmail
 domains: 
   - yggmail
 status: PREPARATION
+strict_tls: false
 server:
   - type: imap
     socket: PLAIN


### PR DESCRIPTION
it would also be disabled if the provider-db is not in use.

`strict_tls` resuls in "certificate_checks = strict"
might be that at some point in the code that is ignored,
however, it seems reasonable to avoid that at all as this reflects the intention better
(and have the same behavior as if provider-db is not in use, which is already tested with yggmail)