### PR TITLE
free infomaniak accounts support max. 10 recipients

### DIFF
--- a/_providers/infomaniak.com.md
+++ b/_providers/infomaniak.com.md
@@ -15,5 +15,6 @@ server:
     port: 465
     username: EMAILADDRESS
 last_checked: 2021-10
+max_smtp_rcpt_to: 10
 website: https://infomaniak.com
 ---


### PR DESCRIPTION
This was found out during tests with github.com/deltachat/eppdperf.

We don't know if paid accounts support more recipients; but as they usually come with a domain of their own, we don't need to distinguish them extra.