### PR TITLE
Disable move to Delta Chat folder for yggmail

### DIFF
--- a/_providers/yggmail.md
+++ b/_providers/yggmail.md
@@ -12,6 +12,8 @@ server:
     socket: PLAIN
     hostname: localhost
     port: 1025
+config_defaults:
+  mvbox_move: 0
 before_login_hint: An Yggmail companion app needs to be installed on your device to access the Yggmail network.
 after_login_hint: |
     Make sure, the Yggmail companion app runs whenever you want to use this account.


### PR DESCRIPTION
there's no a need to move messages to the delta chat folder for yggmail, as it is a per-device account and chat only. Moreover we're working around an yggmail bug that appearantly swallows messages during the move operation.