### PR TITLE
update 163.com

### DIFF
--- a/_providers/163.md
+++ b/_providers/163.md
@@ -1,11 +1,16 @@
 ---
 name: 163 Mail
-status: BROKEN
+status: OK
 domains:
-- 163.com
-before_login_hint: "163 Mail does not work since it forces the email clients to connect with an IMAP ID, which is currently not the case of Delta Chat."
-last_checked: 2021-06
+ - 163.com
+server:
+- type: imap
+  socket: SSL
+  hostname: imap.163.com
+  port: 993
+- type: smtp
+  socket: SSL
+  hostname: smtp.163.com
+  port: 465
+last_checked: 2022-06
 website: https://mail.163.com/
----
-
-163 Mail [forces email clients to provide an IMAP ID](https://help.mail.163.com/faqDetail.do?code=d7a5dc8471cd0c0e8b4b8f4f8e49998b374173cfe9171305fa1ce630d7f67ac211b1978002df8b23), which is currently not the case of Delta Chat.


### PR DESCRIPTION
- IMAP ID will be supported with the next core version, maybe some final tweaking is needed, however, see https://github.com/deltachat/deltachat-core-rust/pull/3468
- i used the server settings from http://help.163.com/09/1223/14/5R7P3QI100753VB8.html 
- i did not find any information that an app password or some IMAP-enable switch are needed for preparation - but i also may easily overseen sth. - i do not speak a word chinese :)

@Micraow @yhh2021 @missytake @link2xt - can you double check as good as you can? esp. the ones how can speak chinese :)

if preparation is needed: what shall we write?

once this is merged: this should be pulled to core and we will do a 1.32 testing release these days, then things can be tried out also in "real".

closes #236