### PR TITLE
Adding Ouvaton to providers list

### DIFF
--- a/_providers/ouvaton.coop.md
+++ b/_providers/ouvaton.coop.md
@@ -1,0 +1,20 @@
+---
+ name: Ouvaton
+ status: OK
+ domains: 
+   - ouvaton.org
+ server:
+   - type: imap
+     socket: SSL
+     hostname: imap.ouvaton.coop
+     port: 993
+     username: EMAILADDRESS
+   - type: smtp
+     socket: SSL
+     hostname: smtp.ouvaton.coop
+     port: 465
+     username: EMAILADDRESS
+ strict_tls: true
+ last_checked: 2022-12
+ website: https://ouvaton.coop
+ ---


### PR DESCRIPTION
A co-operative run hosting provider in France that primarily operates in French and English