### PR TITLE
Improve static text on the index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,36 +12,36 @@ permalink: /
     <link rel="stylesheet" href="./assets/styles.css">
     <link rel="stylesheet" href="./assets/normalize.css">
     <link rel="shortcut icon" href="./assets/provider-db-logo.svg" type="image/x-icon">
-    <title>Provider Overview</title>
+    <title>Email Provider Overview</title>
 </head>
 
 <body>
     <main>
-    <h1 style="margin-bottom: 0.5em;">Provider Database</h1>
+    <h1 style="margin-bottom: 0.5em;">Email Provider Database</h1>
 	
-    <h2 style="margin-bottom: 0.5em;">Does my E-Mail Provider work with Delta Chat?</h2>
+    <h2 style="margin-bottom: 0.5em;">Does my email provider work with Delta Chat?</h2>
 
     <div class="explanation-text">
         <p>
-	You can use your E-Mail account for Delta Chat.
-	This way, you can chat with everyone else who has an E-Mail address.
-	Usually it just works, but for some providers you need to adjust some settings.
-	Just click on "Preparations".
+	You can use your email account for <a href="https://delta.chat/">Delta Chat</a>.
+	This way, you can chat with everyone else who has an email address.
+	Usually, it just works, but for some providers, you need to adjust the settings.
+	In this case, click on &ldquo;prepare&rdquo; for details.
         </p>
         <p>
-	Just look in the table if your E-Mail provider is already tested - it's the part after the @ in your E-Mail address.
-	E.g. if your E-Mail address is jj.doe@gmail.com, then gmail.com is your E-Mail provider.
+	Look in the table if your email provider is already tested — it’s the part after the @ in your email address.
+	E.g. if your email address is jj.doe@gmail.com, then gmail.com is your email provider.
 	<a href="https://delta.chat/help" target="_blank">Other questions?</a>
         </p>
 <!--
 	<p>
-	If you want to create a new E-Mail account for Delta Chat, take a look at our <a href="/new">provider comparison table</a>.
+	If you want to create a new email account for Delta Chat, take a look at our <a href="/new">provider comparison table</a>.
 	You can use it to compare which provider is best suited for your needs, in regards of price, privacy, or whether you need an invite.
         </p>
 -->
         <p>
-            If the information here is out of date, please report it on the <a href="https://github.com/deltachat/provider-db/issues" target="_blank">github issue page</a>.
-            We apreciate pull requests as well :)
+            If the information here is out of date, please report it on the <a href="https://github.com/deltachat/provider-db/issues" target="_blank">GitHub issue page</a>.
+            We appreciate pull requests as well :)
         </p>
     </div>
     </main>


### PR DESCRIPTION
Added Delta Chat link, fixed a typo, added missing commas, used proper quotation marks and apostrophe,
clarified that "provider" is an "email provider".
"E-Mail" is replaced with "email" as it is more common and spelled on Wikipedia and Gmail pages this way.