### PR TITLE
GMX mobile settings don't show IMAP checkbox

### DIFF
--- a/_providers/gmx.net.md
+++ b/_providers/gmx.net.md
@@ -31,6 +31,7 @@ website: https://www.gmx.net/
 ---
 
 To use your GMX email address with Delta Chat you have to enable access for 3rd party applications through IMAP. Please see [GMX's own article on how to do that](https://support.gmx.com/pop-imap/toggle.html).
+(Note: in the GMX settings, if the checkbox isn't visible in your mobile browser, try "Show website as desktop version".)
 
 Afterwards you can use Delta Chat with your GMX email address and the newly created password.
 


### PR DESCRIPTION
@gerryfrancis helped someone with a gmx account to log in to Delta Chat, and noticed that in the mobile version of the GMX website, in the settings, the button to turn on IMAP is missing... there is only "application specific passwords" to choose from, and those in turn only work with 2FA, which then doesn't work with Delta Chat either. The solution was to display the GMX website in the desktop version, where the checkbox is of course available.

![Screenshot_2023-06-14_15-28-57](https://github.com/deltachat/provider-db/assets/57442838/0a1f6bd7-67c9-4f22-bff9-1d00b4c7b204)

I didn't test it since June, because on my laptop it simply works. Maybe someone with a smartphone can quickly check this before we merge this?