### PR TITLE
Make validation pass again

### DIFF
--- a/_providers/arcor.de.md
+++ b/_providers/arcor.de.md
@@ -8,12 +8,12 @@ server:
     socket: SSL
     hostname: imap.arcor.de
     port: 993
-    username: EMAILADDRESS
+    username_pattern: EMAIL
   - type: smtp
     socket: SSL
     hostname: mail.arcor.de
     port: 465
-    username: EMAILADDRESS
+    username_pattern: EMAIL
 last_checked: 2020-05
 website: https://www.arcor.de
 ---

--- a/_providers/blindzeln.org.md
+++ b/_providers/blindzeln.org.md
@@ -9,12 +9,12 @@ server:
     socket: SSL
     hostname: webbox222.server-home.org
     port: 993
-    username: EMAILADDRESS
+    username_pattern: EMAIL
   - type: smtp
     socket: SSL
     hostname: webbox222.server-home.org
     port: 465
-    username: EMAILADDRESS
+    username_pattern: EMAIL
 last_checked: 2021-09
 website: http://www.blindzeln.org
 ---

--- a/_providers/c1.testrun.org.md
+++ b/_providers/c1.testrun.org.md
@@ -8,12 +8,12 @@ server:
     socket: SSL
     hostname: c1.testrun.org
     port: 993
-    username: EMAILADDRESS
+    username_pattern: EMAIL
   - type: smtp
     socket: SSL
     hostname: c1.testrun.org
     port: 465
-    username: EMAILADDRESS
+    username_pattern: EMAIL
 last_checked: 2023-11
 config_defaults:
   mvbox_move: 0

--- a/_providers/c2.testrun.org.md
+++ b/_providers/c2.testrun.org.md
@@ -8,12 +8,12 @@ server:
     socket: SSL
     hostname: c2.testrun.org
     port: 993
-    username: EMAILADDRESS
+    username_pattern: EMAIL
   - type: smtp
     socket: SSL
     hostname: c2.testrun.org
     port: 465
-    username: EMAILADDRESS
+    username_pattern: EMAIL
 last_checked: 2023-11
 config_defaults:
   mvbox_move: 0

--- a/_providers/c3.testrun.org.md
+++ b/_providers/c3.testrun.org.md
@@ -8,12 +8,12 @@ server:
     socket: SSL
     hostname: c3.testrun.org
     port: 993
-    username: EMAILADDRESS
+    username_pattern: EMAIL
   - type: smtp
     socket: SSL
     hostname: c3.testrun.org
     port: 465
-    username: EMAILADDRESS
+    username_pattern: EMAIL
 last_checked: 2023-11
 config_defaults:
   mvbox_move: 0

--- a/_providers/daleth.cafe.md
+++ b/_providers/daleth.cafe.md
@@ -5,7 +5,7 @@ domains:
   - daleth.cafe
 server:
   - type: imap
-    socket: TLS
+    socket: SSL
     hostname: daleth.cafe
     port: 993
     username_pattern: EMAIL

--- a/_providers/disroot.md
+++ b/_providers/disroot.md
@@ -8,12 +8,12 @@ server:
     socket: SSL
     hostname: disroot.org
     port: 993
-    username: EMAILLOCALPART
+    username_pattern: EMAILLOCALPART
   - type: smtp
     socket: STARTTLS
     hostname: disroot.org
     port: 587
-    username: EMAILLOCALPART
+    username_pattern: EMAILLOCALPART
 last_checked: 2017-06
 website: https://disroot.org
 ---

--- a/_providers/e.email.md
+++ b/_providers/e.email.md
@@ -8,12 +8,12 @@ server:
     socket: SSL
     hostname: mail.ecloud.global
     port: 993
-    username: EMAILADDRESS
+    username_pattern: EMAIL
   - type: smtp
     socket: STARTTLS
     hostname: mail.ecloud.global
     port: 587
-    username: EMAILADDRESS
+    username_pattern: EMAIL
 last_checked: 2021-01
 website: https://e.foundation
 ---

--- a/_providers/example.com.md
+++ b/_providers/example.com.md
@@ -10,12 +10,12 @@ server:
     socket: SSL
     hostname: imap.example.com
     port: 1337
-    username: EMAILLOCALPART
+    username_pattern: EMAILLOCALPART
   - type: smtp
     socket: STARTTLS
     hostname: smtp.example.com
     port: 1337
-    username: EMAILADDRESS
+    username_pattern: EMAIL
 before_login_hint: Hush this provider doesn't exist!
 after_login_hint: |
     This provider doesn't really exist, so you can't use it :/

--- a/_providers/fastmail.md
+++ b/_providers/fastmail.md
@@ -157,4 +157,4 @@ Fastmail supports [any of its domains](https://www.fastmail.com/about/ourdomains
 
 The email address you're using with Delta.chat should be entered as the "email" address, while your Fastmail webmail login email address (the one you registered with originally) should be used as the "IMAP Login Name" and "SMTP Login Name".  Your "password" and "SMTP Password" should be the 16-digit password generated for you by Fastmail.  
 
-For security, the SSL/SSL settings should be explicitly selected and used for both IMAP and SMTP, and "Strict" for the Certificate Checks.  Allowing Delta.chat to use "Automatic" for any of these risks an automatic security downgrade in the unlikely event an error is encountered.
+For security, the SSL/TLS settings should be explicitly selected and used for both IMAP and SMTP, and "Strict" for the Certificate Checks.  Allowing Delta.chat to use "Automatic" for any of these risks an automatic security downgrade in the unlikely event an error is encountered.

--- a/_providers/fastmail.md
+++ b/_providers/fastmail.md
@@ -157,4 +157,4 @@ Fastmail supports [any of its domains](https://www.fastmail.com/about/ourdomains
 
 The email address you're using with Delta.chat should be entered as the "email" address, while your Fastmail webmail login email address (the one you registered with originally) should be used as the "IMAP Login Name" and "SMTP Login Name".  Your "password" and "SMTP Password" should be the 16-digit password generated for you by Fastmail.  
 
-For security, the SSL/TLS settings should be explicitly selected and used for both IMAP and SMTP, and "Strict" for the Certificate Checks.  Allowing Delta.chat to use "Automatic" for any of these risks an automatic security downgrade in the unlikely event an error is encountered.
+For security, the SSL/SSL settings should be explicitly selected and used for both IMAP and SMTP, and "Strict" for the Certificate Checks.  Allowing Delta.chat to use "Automatic" for any of these risks an automatic security downgrade in the unlikely event an error is encountered.

--- a/_providers/infomaniak.com.md
+++ b/_providers/infomaniak.com.md
@@ -8,12 +8,12 @@ server:
     socket: SSL
     hostname: mail.infomaniak.com
     port: 993
-    username: EMAILADDRESS
+    username_pattern: EMAIL
   - type: smtp
     socket: SSL
     hostname: mail.infomaniak.com
     port: 465
-    username: EMAILADDRESS
+    username_pattern: EMAIL
 last_checked: 2021-10
 opt:
   max_smtp_rcpt_to: 10

--- a/_providers/mail.com.md
+++ b/_providers/mail.com.md
@@ -191,12 +191,6 @@ domains:
 - tvstar.com
 - uymail.com
 - 2trom.com
-# Keeping this empty so that configuration is handled automatically
-# by Delta Chat.
-# Who knows, maybe they'll stop maintaining one of their domains.
-# The ports/protocols are standard:
-# https://support.mail.com/premium/imap/server.html
-server: []
 before_login_hint: |
   To log in with Delta Chat, you first need to activate POP3/IMAP in your mail.com settings. Note that this is a mail.com Premium feature only.
 last_checked: 2024-03

--- a/_providers/mail.de.md
+++ b/_providers/mail.de.md
@@ -8,12 +8,12 @@ server:
     socket: SSL
     hostname: imap.mail.de
     port: 993
-    username: EMAILADDRESS
+    username_pattern: EMAIL
   - type: smtp
     socket: SSL
     hostname: smtp.mail.de
     port: 465
-    username: EMAILADDRESS
+    username_pattern: EMAIL
 last_checked: 2021-09
 website: https://mail.de
 ---

--- a/_providers/mailbox.org.md
+++ b/_providers/mailbox.org.md
@@ -9,12 +9,12 @@ server:
     socket: SSL
     hostname: imap.mailbox.org
     port: 993
-    username: EMAILADDRESS
+    username_pattern: EMAIL
   - type: smtp
     socket: SSL
     hostname: smtp.mailbox.org
     port: 465
-    username: EMAILADDRESS
+    username_pattern: EMAIL
 last_checked: 2019-03
 website: https://mailbox.org
 ---

--- a/_providers/mehl.cloud.md
+++ b/_providers/mehl.cloud.md
@@ -5,7 +5,7 @@ domains:
   - mehl.cloud
 server:
   - type: imap
-    socket: TLS
+    socket: SSL
     hostname: mehl.cloud
     port: 993
     username_pattern: EMAIL

--- a/_providers/mehl.store.md
+++ b/_providers/mehl.store.md
@@ -15,12 +15,12 @@ server:
     socket: SSL
     hostname: mail.ende.in.net
     port: 993
-    username: EMAILADDRESS
+    username_pattern: EMAIL
   - type: smtp
     socket: STARTTLS
     hostname: mail.ende.in.net
     port: 587
-    username: EMAILADDRESS
+    username_pattern: EMAIL
 before_login_hint: 
 after_login_hint: |
     This account provides 3GB storage for eMails and the possibility to access a NEXTCLOUD-instance by using the email-credits!

--- a/_providers/nine.testrun.org.md
+++ b/_providers/nine.testrun.org.md
@@ -8,12 +8,12 @@ server:
     socket: SSL
     hostname: nine.testrun.org
     port: 993
-    username: EMAILADDRESS
+    username_pattern: EMAIL
   - type: smtp
     socket: SSL
     hostname: nine.testrun.org
     port: 465
-    username: EMAILADDRESS
+    username_pattern: EMAIL
 last_checked: 2023-11
 config_defaults:
   mvbox_move: 0

--- a/_providers/nubo.coop.md
+++ b/_providers/nubo.coop.md
@@ -8,12 +8,12 @@ server:
     socket: SSL
     hostname: mail.nubo.coop
     port: 993
-    username: EMAILADDRESS
+    username_pattern: EMAIL
   - type: smtp
     socket: SSL
     hostname: mail.nubo.coop
     port: 465
-    username: EMAILADDRESS
+    username_pattern: EMAIL
 last_checked: 2022-12
 website: https://nubo.coop
 ---

--- a/_providers/ouvaton.coop.md
+++ b/_providers/ouvaton.coop.md
@@ -8,12 +8,12 @@
      socket: SSL
      hostname: imap.ouvaton.coop
      port: 993
-     username: EMAILADDRESS
+     username_pattern: EMAIL
    - type: smtp
      socket: SSL
      hostname: smtp.ouvaton.coop
      port: 465
-     username: EMAILADDRESS
+     username_pattern: EMAIL
  last_checked: 2022-12
  website: https://ouvaton.coop
 ---

--- a/_providers/purelymail.com.md
+++ b/_providers/purelymail.com.md
@@ -12,12 +12,12 @@ server:
     socket: SSL
     hostname: imap.purelymail.com
     port: 993
-    username: EMAILADDRESS
+    username_pattern: EMAIL
   - type: smtp
     socket: SSL
     hostname: smtp.purelymail.com
     port: 465
-    username: EMAILADDRESS
+    username_pattern: EMAIL
 last_checked: 2023-12
 website: https://purelymail.com
 ---

--- a/_providers/riseup.net.md
+++ b/_providers/riseup.net.md
@@ -8,12 +8,12 @@ server:
     socket: SSL
     hostname: mail.riseup.net
     port: 993
-    username: EMAILLOCALPART
+    username_pattern: EMAILLOCALPART
   - type: smtp
     socket: SSL
     hostname: mail.riseup.net
     port: 465
-    username: EMAILLOCALPART
+    username_pattern: EMAILLOCALPART
 last_checked: 2017-12
 website: https://riseup.net/
 ---

--- a/_providers/systemausfall.org.md
+++ b/_providers/systemausfall.org.md
@@ -9,12 +9,12 @@ server:
     socket: SSL
     hostname: mail.systemausfall.org
     port: 993
-    username: EMAILADDRESS
+    username_pattern: EMAIL
   - type: smtp
     socket: SSL
     hostname: mail.systemausfall.org
     port: 465
-    username: EMAILADDRESS
+    username_pattern: EMAIL
 last_checked: 2021-05
 website: https://systemausfall.org
 ---

--- a/_providers/systemli.org.md
+++ b/_providers/systemli.org.md
@@ -8,12 +8,12 @@ server:
     socket: SSL
     hostname: mail.systemli.org
     port: 993
-    username: EMAILADDRESS
+    username_pattern: EMAIL
   - type: smtp
     socket: SSL
     hostname: mail.systemli.org
     port: 465
-    username: EMAILADDRESS
+    username_pattern: EMAIL
 last_checked: 2020-05
 website: https://www.systemli.org/
 ---

--- a/validation/index.js
+++ b/validation/index.js
@@ -75,13 +75,23 @@ function test(fileContent) {
 
     // is server data populated?
     if(json.server){
+        var has_smtp = false;
+        var has_imap = false;
         json.server.forEach(server => {
             try {
                 testServer(server)
+                if (server.type == "imap") {
+                    has_imap = true
+                } else if (server.type == "smtp") {
+                    has_smtp = true
+                }
             } catch (error) {
                 throw new Error("Error in server definition:" + error.message)
             }
         });
+        if(!(has_imap && has_smtp)){
+            throw new Error("Server definition needs atlease one server of both types")
+        }
     }
 
     // Check that config contains only valid keys

--- a/validation/index.js
+++ b/validation/index.js
@@ -75,23 +75,13 @@ function test(fileContent) {
 
     // is server data populated?
     if(json.server){
-        var has_smtp = false;
-        var has_imap = false;
         json.server.forEach(server => {
             try {
                 testServer(server)
-                if (server.type == "imap") {
-                    has_imap = true
-                } else if (server.type == "smtp") {
-                    has_smtp = true
-                }
             } catch (error) {
                 throw new Error("Error in server definition:" + error.message)
             }
         });
-        if(!(has_imap && has_smtp)){
-            throw new Error("Server definition needs atlease one server of both types")
-        }
     }
 
     // Check that config contains only valid keys


### PR DESCRIPTION
@WofWca I removed the empty server block in `mail.com.md` again (which was introduced in #287) - doesn't core try out common server names anyway? There are many providers without a server block, this is quite typical.