### PR TITLE
Add more ports for chatmail servers and testrun.org

### DIFF
--- a/_providers/acesttoi.fr
+++ b/_providers/acesttoi.fr
@@ -10,11 +10,21 @@ server:
     port: 993
     username_pattern: EMAIL
   - type: smtp
+    socket: SSL
+    hostname: acesttoi.fr
+    port: 465
+    username_pattern: EMAIL
+  - type: imap
+    socket: STARTTLS
+    hostname: acesttoi.fr
+    port: 143
+    username_pattern: EMAIL
+  - type: smtp
     socket: STARTTLS
     hostname: acesttoi.fr
     port: 587
     username_pattern: EMAIL
-last_checked: 2024-05
+last_checked: 2024-06
 skip_auto_test: false
 website: https://warum.daleth.cafe
 ---

--- a/_providers/daleth.cafe.md
+++ b/_providers/daleth.cafe.md
@@ -10,11 +10,21 @@ server:
     port: 993
     username_pattern: EMAIL
   - type: smtp
+    socket: SSL
+    hostname: daleth.cafe
+    port: 465
+    username_pattern: EMAIL
+  - type: imap
+    socket: STARTTLS
+    hostname: daleth.cafe
+    port: 143
+    username_pattern: EMAIL
+  - type: smtp
     socket: STARTTLS
     hostname: daleth.cafe
     port: 587
     username_pattern: EMAIL
-last_checked: 2024-02
+last_checked: 2024-06
 skip_auto_test: false
 website: https://nein.jetzt
 ---

--- a/_providers/mehl.cloud.md
+++ b/_providers/mehl.cloud.md
@@ -10,11 +10,21 @@ server:
     port: 993
     username_pattern: EMAIL
   - type: smtp
+    socket: SSL
+    hostname: mehl.cloud
+    port: 465
+    username_pattern: EMAIL
+  - type: imap
+    socket: STARTTLS
+    hostname: mehl.cloud
+    port: 143
+    username_pattern: EMAIL
+  - type: smtp
     socket: STARTTLS
     hostname: mehl.cloud
     port: 587
     username_pattern: EMAIL
-last_checked: 2024-02
+last_checked: 2024-06
 skip_auto_test: false
 website: https://nein.jetzt
 ---

--- a/_providers/nine.testrun.org.md
+++ b/_providers/nine.testrun.org.md
@@ -14,7 +14,17 @@ server:
     hostname: nine.testrun.org
     port: 465
     username_pattern: EMAIL
-last_checked: 2023-11
+  - type: imap
+    socket: STARTTLS
+    hostname: nine.testrun.org
+    port: 143
+    username_pattern: EMAIL
+  - type: smtp
+    socket: STARTTLS
+    hostname: nine.testrun.org
+    port: 587
+    username_pattern: EMAIL
+last_checked: 2024-06
 config_defaults:
   mvbox_move: 0
 website: https://nine.testrun.org/

--- a/_providers/testrun.md
+++ b/_providers/testrun.md
@@ -8,6 +8,10 @@ server:
   hostname: testrun.org
   port: 993
   socket: SSL
+- type: smtp
+  hostname: testrun.org
+  port: 465
+  socket: SSL
 - type: imap
   hostname: testrun.org
   port: 143


### PR DESCRIPTION
SSL is preferred over STARTTLS,
but STARTTLS is used as a fallback in case SSL port is blocked.

This is supposed to address https://support.delta.chat/t/could-provide-a-set-of-non-standard-ports-on-nine-testrun-org/3157/8