### PR TITLE
change vk.com from BROKEN to PREPARATION

### DIFF
--- a/_providers/vk.com.md
+++ b/_providers/vk.com.md
@@ -1,20 +1,37 @@
 ---
 name: VK Mail
-status: BROKEN
+status: PREPARATION
 domains:
 - vk.com
+# Source: https://vk.com/wall-104054395_14970?w=wall-104054395_14970_r26667
+# But their FAQ still states that vk.com can't work with other email clients:
+# https://help.vk.mail.ru/vkmail/questions/client
+# Maybe they just haven't updated it yet?
+# Or maybe they're just testing and might disable it again, as it once happened:
+# https://vk.com/wall-104054395_14970?w=wall-104054395_14970_r15160
+#
+server:
+  - type: imap
+    socket: SSL
+    # The vk.com service is ruled by the same company as mail.ru.
+    # For mail.ru see ./mail.ru.md
+    hostname: imap.mail.ru
+    port: 993
+  - type: smtp
+    socket: SSL
+    hostname: smtp.mail.ru
+    port: 465
+# I have tried to find a way to get to this link through the UI, but couldn't.
 before_login_hint: |
-  К сожалению, VK Почта не поддерживает работу с Delta Chat.
-  См. https://help.vk.mail.ru/vkmail/questions/client
-last_checked: 2024-03
+  Вам необходимо сгенерировать "пароль для внешнего приложения" в веб-интерфейсе mail.ru
+  https://account.mail.ru/user/2-step-auth/passwords/
+  чтобы vk.com работал с Delta Chat.
+last_checked: 2024-07
 website: https://vk.mail.ru/
+# Also apparently OAuth is supported as well:
+# https://support.delta.chat/t/oauth2-vk-com/1854?u=wofwca
 ---
 
-К сожалению, VK Почта не поддерживает работу с Delta Chat и другими сторонними клиентами.
-См. <https://help.vk.mail.ru/vkmail/questions/client>
-
-<!-- Apparently it used to sort of work, but then they disabled it
-https://vk.com/wall-104054395_14970?w=wall-104054395_14970_r15160 -->
-
-<!-- The vk.com service is ruled by the same company as mail.ru, but they
-still have different mail services apparently. -->
+Вам необходимо сгенерировать "пароль для внешнего приложения" в веб-интерфейсе mail.ru
+<https://account.mail.ru/user/2-step-auth/passwords/>
+чтобы vk.com работал с Delta Chat.


### PR DESCRIPTION
I have verified it, it works. I can receive emails.

But their FAQ still states that vk.com can't work
with other email clients:
https://help.vk.mail.ru/vkmail/questions/client
Maybe they just haven't updated it yet?
Or maybe they're just testing and might disable it again, as it once happened:
https://vk.com/wall-104054395_14970?w=wall-104054395_14970_r15160

- [ ] Maybe it's worth waiting a bit, at least before the next DC release to see if it breaks again. Ping me and I'll test.