### PR TITLE
riseup.net: include domain into the username

### DIFF
--- a/_providers/riseup.net.md
+++ b/_providers/riseup.net.md
@@ -8,12 +8,12 @@ server:
     socket: SSL
     hostname: mail.riseup.net
     port: 993
-    username_pattern: EMAILLOCALPART
+    username_pattern: EMAIL
   - type: smtp
     socket: SSL
     hostname: mail.riseup.net
     port: 465
-    username_pattern: EMAILLOCALPART
-last_checked: 2017-12
+    username_pattern: EMAIL
+last_checked: 2024-08
 website: https://riseup.net/
 ---


### PR DESCRIPTION
I have checked by configuring testing account
manually with username being a full email
instead of just the local part.

This is how it is specified in
<https://autoconfig.riseup.net/mail/config-v1.1.xml>

I also tested manually with openssl-s_client
that IMAP server at mail.riseup.net:993 accepts username
both with and without the domain name.
Domain name is however not ignored,
it is impossible to login as "user@example.org"
if your email address is "user@riseup.net",
but using just "user" is fine.
