### PR TITLE
Add Migadu

### DIFF
--- a/_providers/migadu.md
+++ b/_providers/migadu.md
@@ -1,0 +1,24 @@
+---
+name: Migadu
+status: OK
+domains:
+  - migadu.com
+server:
+  - type: imap
+    socket: SSL
+    hostname: imap.migadu.com
+    port: 993
+    username_pattern: EMAIL
+  - type: smtp
+    socket: SSL
+    hostname: smtp.migadu.com
+    port: 465
+    username_pattern: EMAIL
+  - type: smtp
+    socket: STARTTLS
+    hostname: smtp.migadu.com
+    port: 587
+    username_pattern: EMAIL
+last_checked: 2024-09
+website: https://www.migadu.com/
+---


### PR DESCRIPTION
Port 587 is not in https://autoconfig.migadu.com/mail/config-v1.1.xml but it is documented in https://www.migadu.com/guides/outlook_android/ and works, so adding to the provider database will allow the client to also use STARTTLS over 587 if 465 does not work.