### PR TITLE
Remove OAUTH2 for gmail

### DIFF
--- a/_providers/gmail.md
+++ b/_providers/gmail.md
@@ -5,7 +5,6 @@ domains:
   - gmail.com
   - googlemail.com
   - google.com
-oauth2: gmail
 server:
   - type: imap
     socket: SSL


### PR DESCRIPTION
Delta Chat does not have working gmail client ID anymore.