### PR TITLE
Update icloud.md for Custom Email Domain

### DIFF
--- a/_providers/icloud.md
+++ b/_providers/icloud.md
@@ -21,3 +21,8 @@ website: https://www.icloud.com/mail
 ---
 
 To use Delta Chat with your iCloud email address [it is required to generate a specific password for it](https://support.apple.com/en-us/HT202304). Afterwards you can use Delta Chat with your iCloud email address and the newly created password.
+
+When using a Custom Email Domain hosted on iCloud+ you need to: 
+- fill in the address you want to use for Delta Chat in the "E-Mail Adress" field,
+- fill in your iCloud login email in "Advanced > IMAP Login Name" and "Advanced > SMTP Login Name", and
+- fill "Advanced > IMAP Server" with "imap.mail.me.com" and "Advanced > SMTP Server" with "smtp.mail.me.com".


### PR DESCRIPTION
Figured out how to use Custom Email Domain hosted on iCloud+. I'd like to update the description of iCloud provider to maybe save the next person some time.

I don't know if formatting lists the way I did works in provider description (or if this is even the right place to add this information) so please let me know if this is wrong.