### PR TITLE
feat: Remove sentbox_watch

### DIFF
--- a/_providers/five.chat.md
+++ b/_providers/five.chat.md
@@ -5,7 +5,6 @@ domains:
 - five.chat
 config_defaults:
   bcc_self: 1
-  sentbox_watch: 0
   mvbox_move: 0
 website: https://five.chat
 last_checked: 2020-06

--- a/_providers/nauta.cu.md
+++ b/_providers/nauta.cu.md
@@ -17,7 +17,6 @@ server:
     port: 25
 config_defaults:
   delete_server_after: 1
-  sentbox_watch: 0
   mvbox_move: 0
   media_quality: 1
 last_checked: 2024-01

--- a/_providers/testrun.md
+++ b/_providers/testrun.md
@@ -22,7 +22,6 @@ server:
   socket: STARTTLS
 config_defaults:
   bcc_self: 1
-  sentbox_watch: 0
   mvbox_move: 0
 website: https://testrun.org
 last_checked: 2020-06


### PR DESCRIPTION
This changes nothing, all providers having sentbox_watch set it to 0 anyway. sentbox_watch is to be removed from Chatmail Core soon. Sentbox will be fetched after fetching new messages from Inbox, but debounced to once per minute.