### PR TITLE
Remove mvbox_move

### DIFF
--- a/_providers/five.chat.md
+++ b/_providers/five.chat.md
@@ -5,7 +5,6 @@ domains:
 - five.chat
 config_defaults:
   bcc_self: 1
-  mvbox_move: 0
 website: https://five.chat
 last_checked: 2020-06
 ---

--- a/_providers/nauta.cu.md
+++ b/_providers/nauta.cu.md
@@ -17,7 +17,6 @@ server:
     port: 25
 config_defaults:
   delete_server_after: 1
-  mvbox_move: 0
   media_quality: 1
 last_checked: 2024-01
 skip_auto_test: true

--- a/_providers/nine.testrun.org.md
+++ b/_providers/nine.testrun.org.md
@@ -35,7 +35,5 @@ server:
     port: 587
     username_pattern: EMAIL
 last_checked: 2024-06
-config_defaults:
-  mvbox_move: 0
 website: https://nine.testrun.org/
 ---

--- a/_providers/testrun.md
+++ b/_providers/testrun.md
@@ -22,7 +22,6 @@ server:
   socket: STARTTLS
 config_defaults:
   bcc_self: 1
-  mvbox_move: 0
 website: https://testrun.org
 last_checked: 2020-06
 ---

--- a/_providers/yggmail.md
+++ b/_providers/yggmail.md
@@ -12,8 +12,6 @@ server:
     socket: PLAIN
     hostname: localhost
     port: 1025
-config_defaults:
-  mvbox_move: 0
 before_login_hint: An Yggmail companion app needs to be installed on your device to access the Yggmail network.
 after_login_hint: |
     Make sure, the Yggmail companion app runs whenever you want to use this account.


### PR DESCRIPTION
mvbox_move is a legacy option that is going to be removed and already defaults to not moving during initial configuration.