### PR TITLE
Remove show_emails option

### DIFF
--- a/_providers/hermes.radio.md
+++ b/_providers/hermes.radio.md
@@ -8,7 +8,6 @@ opt:
   strict_tls: false
 config_defaults:
   mdns_enabled: 0
-  show_emails: 2
 last_checked: 2022-06
 website: http://hermes.radio
 ---


### PR DESCRIPTION
It is going to be removed in
<https://github.com/chatmail/core/pull/7632>

Unclear if hermes.radio is even working with
current versions of Delta Chat because it depends
on disabling encryption, but I kept it as is.